### PR TITLE
Prefer importing real modules to auto-gen mocks

### DIFF
--- a/charms/unit_test.py
+++ b/charms/unit_test.py
@@ -6,6 +6,13 @@ from itertools import accumulate
 from unittest.mock import MagicMock, patch
 
 
+try:
+    ModuleNotFoundError
+except NameError:
+    # python 3.5 compatibility
+    ModuleNotFoundError = ImportError
+
+
 def identity(x):
     return x
 

--- a/charms/unit_test.py
+++ b/charms/unit_test.py
@@ -1,8 +1,9 @@
 import os
 import sys
+import importlib.util
 from importlib.machinery import ModuleSpec
 from itertools import accumulate
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 def identity(x):
@@ -24,6 +25,24 @@ class MockPackage(MagicMock):
 
 class MockFinder:
     def find_spec(self, fullname, path, target=None):
+        # defer to things actually on disk; to do so, though, we have to
+        # temporarily remove any patched modules from sys.modules, or they will
+        # prevent the normal discovery method from working, as well as
+        # temporarily removing this finder from sys.meta_path to prevent
+        # infinite recursion
+        with patch.dict(sys.modules, clear=True,
+                        values={name: mod for name, mod in sys.modules.items()
+                                if not isinstance(mod, MockPackage)}):
+            with patch('sys.meta_path',
+                       [finder for finder in sys.meta_path
+                        if not isinstance(finder, MockFinder)]):
+                try:
+                    file_spec = importlib.util.find_spec(fullname)
+                    if file_spec:
+                        return file_spec
+                except ModuleNotFoundError:
+                    pass
+        # otherwise, see if we've patched something related
         for method in (self._find_exact,
                        self._find_patched_parent,
                        self._find_patched_child):

--- a/tests/lib/patched/__init__.py
+++ b/tests/lib/patched/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/tests/lib/patched/module/__init__.py
+++ b/tests/lib/patched/module/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/tests/lib/patched/module/import_over_patch.py
+++ b/tests/lib/patched/module/import_over_patch.py
@@ -1,0 +1,1 @@
+real_or_fake = 'real'

--- a/tests/test_charms_unit_test.py
+++ b/tests/test_charms_unit_test.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -40,3 +41,10 @@ def test_patched_child():
     import dummy.test
     assert isinstance(dummy.test.module, unit_test.MockPackage)
     assert isinstance(dummy.test.module.foo, MagicMock)
+
+
+def test_import_over_patch():
+    sys.path.insert(0, str(Path(__file__).parent / 'lib'))
+    unit_test.patch_module('patched.module')
+    from patched.module.import_over_patch import real_or_fake
+    assert real_or_fake == 'real'


### PR DESCRIPTION
If a real module is imported which happens to have a parent mocked, we should prefer the real module to generating a new mock module in its place.  For example, `patch_reactive()` mocks out `charms.layer` but this was preventing the charms from importing their own local layer code.