### PR TITLE
Refactor to simplify logic, and add patch_fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+from charms import unit_test
+
+
+def pytest_addoption(parser):
+    parser.addoption("--debug-tests", action="store_true")
+
+
+@pytest.fixture(autouse=True)
+def cmdopt(request):
+    if request.config.getoption("--debug-tests"):
+        unit_test._debug = _debug_pront
+
+
+def _debug_pront(msg, *args, color=None, **kwargs):
+    colors = {
+        'red': '\x1b[31m',
+        'green': '\x1b[32m',
+        'yellow': '\x1b[33m',
+        'blue': '\x1b[34m',
+        'magenta': '\x1b[35m',
+        'cyan': '\x1b[36m',
+    }
+    if color:
+        msg = colors[color] + msg + '\x1b[0m'
+    print(msg.format(*args, **kwargs))

--- a/tests/test_charms_unit_test.py
+++ b/tests/test_charms_unit_test.py
@@ -15,39 +15,69 @@ def clean_imports():
     sys.modules.update(sys_modules)
 
 
-def test_exact_match():
+def test_patch():
     unit_test.patch_module('dummy')
     import dummy
     assert isinstance(dummy, unit_test.MockPackage)
     assert isinstance(dummy.foo, MagicMock)
 
 
-def test_patched_parent():
+def test_patch_with_patched_ancestor():
     unit_test.patch_module('dummy')
-    import dummy.test
-    assert isinstance(dummy.test, unit_test.MockPackage)
-    assert isinstance(dummy.test.foo, MagicMock)
+    unit_test.patch_module('dummy.test')
+    import dummy.test as dummy_test
+    import dummy
+    assert isinstance(dummy_test, unit_test.MockPackage)
+    assert isinstance(dummy_test.foo, MagicMock)
+    assert dummy.test is dummy_test
 
 
-def test_patched_parent_existing_namespace():
+def test_patch_with_real_ancestor():
     unit_test.patch_module('charms.dummy')
-    import charms.dummy.test
-    assert isinstance(charms.dummy.test, unit_test.MockPackage)
-    assert isinstance(charms.dummy.test.foo, MagicMock)
+    import charms.dummy as charms_dummy
+    import charms
+    assert isinstance(charms_dummy, unit_test.MockPackage)
+    assert isinstance(charms_dummy.foo, MagicMock)
+    assert charms.dummy is charms_dummy
 
 
-def test_patched_child():
+def test_unpatched_missing():
+    with pytest.raises(ImportError):
+        import dummy.test  # noqa
+
+
+def test_unpatched_with_real_ancestor():
+    with pytest.raises(ImportError):
+        import charms.dummy.test  # noqa
+
+
+def test_unpatched_with_patched_ancestor():
+    unit_test.patch_module('dummy')
+    import dummy.test.module as dummy_test_module
+    import dummy
+    assert isinstance(dummy_test_module, unit_test.MockPackage)
+    assert isinstance(dummy_test_module.foo, MagicMock)
+    assert dummy.test.module is dummy_test_module
+
+
+def test_unpatched_with_patched_child():
     unit_test.patch_module('dummy.test.module')
     import dummy.test
+    import dummy.test.module as dummy_test_module
+    assert isinstance(dummy.test, unit_test.MockPackage)
     assert isinstance(dummy.test.module, unit_test.MockPackage)
-    assert isinstance(dummy.test.module.foo, MagicMock)
+    assert isinstance(dummy.test.foo, MagicMock)
+    assert dummy.test.module is dummy_test_module
 
 
-def test_import_over_patch():
+def test_import_real_over_patched_ancestor():
     sys.path.insert(0, str(Path(__file__).parent / 'lib'))
     unit_test.patch_module('patched.module')
-    from patched.module.import_over_patch import real_or_fake
-    assert real_or_fake == 'real'
+    import patched.module.import_over_patch as import_over_patch
+    import patched.module
+    assert not isinstance(import_over_patch, unit_test.MockPackage)
+    assert import_over_patch.real_or_fake == 'real'
+    assert patched.module.import_over_patch is import_over_patch
 
 
 def test_auto_import_mock_package():


### PR DESCRIPTION
The searching and patching logic was unnecessarily complex. This refactors it to be cleaner and also adds the patch_fixture helper to create fixtures which apply a patch.