### PR TITLE
Fix pre-patch attribute import

### DIFF
--- a/tests/test_charms_unit_test.py
+++ b/tests/test_charms_unit_test.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -18,7 +18,7 @@ def clean_imports():
 def test_patch():
     unit_test.patch_module('dummy')
     import dummy
-    assert isinstance(dummy, unit_test.MockPackage)
+    assert isinstance(dummy, MagicMock)
     assert isinstance(dummy.foo, MagicMock)
 
 
@@ -27,8 +27,7 @@ def test_patch_with_patched_ancestor():
     unit_test.patch_module('dummy.test')
     import dummy.test as dummy_test
     import dummy
-    assert isinstance(dummy_test, unit_test.MockPackage)
-    assert isinstance(dummy_test.foo, MagicMock)
+    assert isinstance(dummy_test, MagicMock)
     assert dummy.test is dummy_test
 
 
@@ -36,8 +35,7 @@ def test_patch_with_real_ancestor():
     unit_test.patch_module('charms.dummy')
     import charms.dummy as charms_dummy
     import charms
-    assert isinstance(charms_dummy, unit_test.MockPackage)
-    assert isinstance(charms_dummy.foo, MagicMock)
+    assert isinstance(charms_dummy, MagicMock)
     assert charms.dummy is charms_dummy
 
 
@@ -53,20 +51,18 @@ def test_unpatched_with_real_ancestor():
 
 def test_unpatched_with_patched_ancestor():
     unit_test.patch_module('dummy')
+    from dummy import test
     import dummy.test.module as dummy_test_module
-    import dummy
-    assert isinstance(dummy_test_module, unit_test.MockPackage)
-    assert isinstance(dummy_test_module.foo, MagicMock)
-    assert dummy.test.module is dummy_test_module
+    assert isinstance(dummy_test_module, MagicMock)
+    assert test.module is dummy_test_module
 
 
 def test_unpatched_with_patched_child():
     unit_test.patch_module('dummy.test.module')
     import dummy.test
     import dummy.test.module as dummy_test_module
-    assert isinstance(dummy.test, unit_test.MockPackage)
-    assert isinstance(dummy.test.module, unit_test.MockPackage)
-    assert isinstance(dummy.test.foo, MagicMock)
+    assert isinstance(dummy.test, MagicMock)
+    assert isinstance(dummy.test.module, MagicMock)
     assert dummy.test.module is dummy_test_module
 
 
@@ -75,8 +71,8 @@ def test_import_real_over_patched_ancestor():
     unit_test.patch_module('patched.module')
     import patched.module.import_over_patch as import_over_patch
     import patched.module
-    assert not isinstance(import_over_patch, unit_test.MockPackage)
-    assert isinstance(patched.module, unit_test.MockPackage)
+    assert not isinstance(import_over_patch, MagicMock)
+    assert isinstance(patched.module, MagicMock)
     assert import_over_patch.real_or_fake == 'real'
     assert patched.module.import_over_patch is import_over_patch
 
@@ -86,9 +82,8 @@ def test_auto_import_mock_package():
     import patched
     mock_package = unit_test.AutoImportMockPackage(name='patched.module')
     unit_test.patch_module('patched.module', mock_package)
-    assert not isinstance(patched.module.import_over_patch,
-                          unit_test.MockPackage)
-    assert isinstance(patched.module, unit_test.MockPackage)
+    assert not isinstance(patched.module.import_over_patch, MagicMock)
+    assert isinstance(patched.module, MagicMock)
     assert patched.module.import_over_patch.real_or_fake == 'real'
 
 
@@ -98,8 +93,8 @@ def test_auto_import_mock_package_from_syntax():
     mock_package = unit_test.AutoImportMockPackage(name='patched.module')
     unit_test.patch_module('patched.module', mock_package)
     from patched.module import import_over_patch
-    assert not isinstance(import_over_patch, unit_test.MockPackage)
-    assert isinstance(patched.module, unit_test.MockPackage)
+    assert not isinstance(import_over_patch, MagicMock)
+    assert isinstance(patched.module, MagicMock)
     assert import_over_patch.real_or_fake == 'real'
 
 
@@ -108,9 +103,8 @@ def test_auto_import_mock_package_top_level():
     mock_package = unit_test.AutoImportMockPackage(name='module')
     unit_test.patch_module('module', mock_package)
     import module
-    assert not isinstance(module.import_over_patch,
-                          unit_test.MockPackage)
-    assert isinstance(module, unit_test.MockPackage)
+    assert not isinstance(module.import_over_patch, MagicMock)
+    assert isinstance(module, MagicMock)
     assert module.import_over_patch.real_or_fake == 'real'
 
 


### PR DESCRIPTION
If a submodule is imported as an attribute (i.e., `from foo import bar`) prior to it being explicitly patched or auto-loaded, the attribute import ended up getting a different mock instance than the explicit or auto-loaded import.

This also removes the MockPackage class because we can't actually know ahead of time which attributes should be treated like a package or not.