### PR TITLE
Patch charms.layer.import_layer_libs

### DIFF
--- a/charms/__init__.py
+++ b/charms/__init__.py
@@ -1,2 +1,0 @@
-from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)

--- a/tests/lib/patched/__init__.py
+++ b/tests/lib/patched/__init__.py
@@ -1,2 +1,0 @@
-from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)

--- a/tests/lib/patched/module/__init__.py
+++ b/tests/lib/patched/module/__init__.py
@@ -1,2 +1,0 @@
-from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)

--- a/tests/test_charms_unit_test.py
+++ b/tests/test_charms_unit_test.py
@@ -110,9 +110,11 @@ def test_auto_import_mock_package_top_level():
 
 def test_patch_reactive():
     unit_test.patch_reactive()
+    import charms
     import charms.templating  # noqa
     import charms.layer.foo  # noqa
     import charmhelpers
+    from charms.layer import import_layer_libs  # noqa
     from charms.reactive import when, when_all, when_not_all
     from charms.reactive import set_flag, clear_flag, is_flag_set
     from charms.reactive import set_state, remove_state, is_state
@@ -151,3 +153,5 @@ def test_patch_reactive():
     remove_state('foo')
     assert not is_flag_set('foo')
     assert not is_state('foo')
+
+    assert charms.layer.import_layer_libs

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist = lint,py3
 basepython = python3
 setenv =
     PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
 deps =
     pytest
     flake8


### PR DESCRIPTION
This function is normally handled automatically but actions have to manually call it, so we need to ensure it's available.

Fixing this uncovered the reason why the patched modules were losing their attribute attachment to their parents: `patch.dict()` was restoring the hidden patched modules but was losing the attribute attachment, and this could actually affect things other than the auto-importer, so now it's fixed more generally.