### PR TITLE
sort the modules we want to hide

### DIFF
--- a/charms/unit_test.py
+++ b/charms/unit_test.py
@@ -88,7 +88,7 @@ def _hide_patched_modules():
     try:
         yield
     finally:
-        for name, mod in patches.items():
+        for name, mod in sorted(patches.items()):
             sys.modules[name] = mod
             if '.' in name:
                 parent, attr = name.rsplit('.', 1)


### PR DESCRIPTION
py35 travis was failing because we might attempt to setattr on something
like 'charmhelpers.foo' when 'charmhelpers' itself isn't in sys.modules
yet. Fix it by sorting the modules-to-be-patched so foo comes before
foo.bar.

Not a problem with newer pythons because of the dict insertion order
preservation, but it doesn't hurt to always sort.