### PR TITLE
Allow patch_module to be used as a context manager

### DIFF
--- a/charms/unit_test.py
+++ b/charms/unit_test.py
@@ -202,7 +202,7 @@ def patch_module(fullname, replacement=None):
     """
     patched = []
 
-    def _unpatch(*a):
+    def _unpatch(*_):
         for module_name in patched:
             del sys.modules[module_name]
 
@@ -210,8 +210,8 @@ def patch_module(fullname, replacement=None):
         if ancestor not in sys.modules:
             MockLoader.load_module(ancestor)
             patched.append(ancestor)
-    replacement = MockLoader.load_module(fullname, replacement)
     patched.append(fullname)
+    replacement = MockLoader.load_module(fullname, replacement)
     replacement.__enter__ = lambda s: replacement
     replacement.__exit__ = _unpatch
     return replacement

--- a/charms/unit_test.py
+++ b/charms/unit_test.py
@@ -200,10 +200,21 @@ def patch_module(fullname, replacement=None):
     """
     Patch a module (and potentially all of its parent packages).
     """
+    patched = []
+
+    def _unpatch(*a):
+        for module_name in patched:
+            del sys.modules[module_name]
+
     for ancestor in module_ancestors(fullname):
         if ancestor not in sys.modules:
             MockLoader.load_module(ancestor)
-    return MockLoader.load_module(fullname, replacement)
+            patched.append(ancestor)
+    replacement = MockLoader.load_module(fullname, replacement)
+    patched.append(fullname)
+    replacement.__enter__ = lambda s: replacement
+    replacement.__exit__ = _unpatch
+    return replacement
 
 
 def patch_fixture(patch_target, new=DEFAULT,

--- a/tests/test_charms_unit_test.py
+++ b/tests/test_charms_unit_test.py
@@ -22,6 +22,14 @@ def test_patch():
     assert isinstance(dummy.foo, MagicMock)
 
 
+def test_patch_cm():
+    with unit_test.patch_module('dummy.test.foo') as _foo:
+        from dummy.test import foo
+        assert foo is _foo
+    with pytest.raises(ImportError):
+        from dummy.test import foo
+
+
 def test_patch_with_patched_ancestor():
     unit_test.patch_module('dummy')
     unit_test.patch_module('dummy.test')


### PR DESCRIPTION
This allows for patched modules to be unloaded if `patch_module` is used as a context manager.