### PR TITLE
Add missing get_flags and get_unset_flags mocks

### DIFF
--- a/charms/unit_test.py
+++ b/charms/unit_test.py
@@ -268,6 +268,8 @@ def patch_reactive():
                                                      else flags.discard(f))
     reactive.is_flag_set.side_effect = lambda f: f in flags
     reactive.is_state.side_effect = lambda f: f in flags
+    reactive.get_flags.side_effect = lambda: sorted(flags)
+    reactive.get_unset_flags.side_effect = lambda *f: sorted(set(f) - flags)
 
     os.environ['JUJU_MODEL_UUID'] = 'test-1234'
     os.environ['JUJU_UNIT_NAME'] = 'test/0'

--- a/tests/test_charms_unit_test.py
+++ b/tests/test_charms_unit_test.py
@@ -125,6 +125,7 @@ def test_patch_reactive():
     from charms.layer import import_layer_libs  # noqa
     from charms.reactive import when, when_all, when_not_all
     from charms.reactive import set_flag, clear_flag, is_flag_set
+    from charms.reactive import get_flags, get_unset_flags
     from charms.reactive import set_state, remove_state, is_state
     from charms.reactive import toggle_flag
 
@@ -166,5 +167,8 @@ def test_patch_reactive():
     assert not is_flag_set('foo')
     toggle_flag('foo', True)
     assert is_flag_set('foo')
+
+    assert get_flags() == ['foo']
+    assert get_unset_flags('foo', 'bar') == ['bar']
 
     assert charms.layer.import_layer_libs


### PR DESCRIPTION
The [PR][] for [lp:1836063][] highlighted the lack of coverage for `get_flags` in `patch_reactive`. It also added a `get_unset_flags`
helper, which was up-ported to charms.reactive in [PR #228][] (note: this PR does not depend on #228 being released first, since we're mocking it anyway).

[PR]: https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/135
[lp:1836063]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1836063
[PR #228]: https://github.com/juju-solutions/charms.reactive/pull/228