### PR TITLE
Add mock base class for Endpoint

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/charms/unit_test.py
+++ b/charms/unit_test.py
@@ -3,7 +3,7 @@ import sys
 import importlib.util
 from contextlib import contextmanager
 from importlib.machinery import ModuleSpec
-from itertools import accumulate
+from itertools import accumulate, chain
 from unittest.mock import DEFAULT, MagicMock, patch
 
 import pytest
@@ -22,15 +22,15 @@ def _debug_noop(msg, *args, color=None, **kwargs):
 
 def _debug_pront(msg, *args, color=None, **kwargs):
     colors = {
-        'red': '\x1b[31m',
-        'green': '\x1b[32m',
-        'yellow': '\x1b[33m',
-        'blue': '\x1b[34m',
-        'magenta': '\x1b[35m',
-        'cyan': '\x1b[36m',
+        "red": "\x1b[31m",
+        "green": "\x1b[32m",
+        "yellow": "\x1b[33m",
+        "blue": "\x1b[34m",
+        "magenta": "\x1b[35m",
+        "cyan": "\x1b[36m",
     }
     if color:
-        msg = colors[color] + msg + '\x1b[0m'
+        msg = colors[color] + msg + "\x1b[0m"
     print(msg.format(*args, **kwargs))
 
 
@@ -44,8 +44,7 @@ def identity(x, *kwargs):
 
 
 def module_ancestors(module_name):
-    tree = list(accumulate(module_name.split('.'),
-                           lambda a, b: '.'.join([a, b])))
+    tree = list(accumulate(module_name.split("."), lambda a, b: ".".join([a, b])))
     return tree[:-1]
 
 
@@ -59,19 +58,18 @@ class AutoImportMockPackage(MagicMock):
         return MagicMock(**kw)
 
     def __getattr__(self, attr):
-        if attr.startswith('_'):
+        if attr.startswith("_"):
             return super().__getattr__(attr)
-        module_name = self.__name__ + '.' + attr
-        _debug('Attempting to auto-load {}', module_name, color='cyan')
+        module_name = self.__name__ + "." + attr
+        _debug("Attempting to auto-load {}", module_name, color="cyan")
         real_spec = MockFinder.find_real(module_name)
         if real_spec:
             module = importlib.import_module(module_name)
             setattr(self, attr, module)
-            _debug('Loaded {}', module, color='green')
+            _debug("Loaded {}", module, color="green")
             return module
         else:
-            _debug('Nothing to load for {}, returning mock', module_name,
-                   color='red')
+            _debug("Nothing to load for {}, returning mock", module_name, color="red")
             return super().__getattr__(attr)
 
 
@@ -90,8 +88,8 @@ def _hide_patched_modules():
     finally:
         for name, mod in sorted(patches.items()):
             sys.modules[name] = mod
-            if '.' in name:
-                parent, attr = name.rsplit('.', 1)
+            if "." in name:
+                parent, attr = name.rsplit(".", 1)
                 setattr(sys.modules[parent], attr, mod)
 
 
@@ -107,13 +105,18 @@ class MockFinder:
         # common example of this is having charms.layer patched but wanting to
         # import the charm's own lib code, from, e.g., charms.layer.my_charm.
         with _hide_patched_modules():
-            with patch('sys.meta_path',
-                       [finder for finder in sys.meta_path
-                        if not isinstance(finder, MockFinder)]):
+            with patch(
+                "sys.meta_path",
+                [
+                    finder
+                    for finder in sys.meta_path
+                    if not isinstance(finder, MockFinder)
+                ],
+            ):
                 try:
                     file_spec = importlib.util.find_spec(fullname)
                     if file_spec:
-                        _debug('Found real module {}', fullname, color='green')
+                        _debug("Found real module {}", fullname, color="green")
                         return file_spec
                 except ModuleNotFoundError:
                     pass
@@ -132,7 +135,7 @@ class MockFinder:
             is the MockFinder or it's one of the standard finders which can't
             find the requested module.
         """
-        _debug('Searching for {}', fullname, color='cyan')
+        _debug("Searching for {}", fullname, color="cyan")
         file_spec = self.find_real(fullname)
         if file_spec:
             return file_spec
@@ -151,22 +154,26 @@ class MockFinder:
             if not existing_module:
                 continue
             if isinstance(existing_module, MagicMock):
-                _debug('Found patched ancestor of {} at {}',
-                       fullname, module_name, color='green')
+                _debug(
+                    "Found patched ancestor of {} at {}",
+                    fullname,
+                    module_name,
+                    color="green",
+                )
                 return ModuleSpec(fullname, MockLoader)
             # If we encounter a real module, we don't want to auto-mock
             # anything below it, even if an earlier ancestor is mocked.
             break
-        _debug('No match found for {}', fullname, color='red')
+        _debug("No match found for {}", fullname, color="red")
         return None
 
 
 class MockLoader:
     @classmethod
     def load_module(cls, fullname, replacement=None):
-        """"Load" a mock module into sys.modules."""
-        if '.' in fullname:
-            parent_name, attr = fullname.rsplit('.', 1)
+        """ "Load" a mock module into sys.modules."""
+        if "." in fullname:
+            parent_name, attr = fullname.rsplit(".", 1)
             parent = sys.modules[parent_name]
             if replacement is None:
                 if isinstance(parent, MagicMock):
@@ -188,11 +195,11 @@ class MockLoader:
         elif replacement is None:
             replacement = MagicMock(name=fullname)
         # Turn mock into a "package".
-        if not hasattr(replacement, '__path__'):
+        if not hasattr(replacement, "__path__"):
             replacement.__name__ = fullname
             replacement.__path__ = []
         sys.modules[fullname] = replacement
-        _debug('Patched {}', fullname, color='green')
+        _debug("Patched {}", fullname, color="green")
         return replacement
 
 
@@ -217,8 +224,7 @@ def patch_module(fullname, replacement=None):
     return replacement
 
 
-def patch_fixture(patch_target, new=DEFAULT,
-                  patch_opts=None, fixture_opts=None):
+def patch_fixture(patch_target, new=DEFAULT, patch_opts=None, fixture_opts=None):
     """
     Create a pytest fixture which patches the target.
 
@@ -229,30 +235,69 @@ def patch_fixture(patch_target, new=DEFAULT,
     fixture_opts = fixture_opts or {}
     patch_opts = patch_opts or {}
     if new is not DEFAULT:
-        patch_opts['new'] = new
+        patch_opts["new"] = new
 
     @pytest.fixture(**fixture_opts)
     def _fixture():
         with patch(patch_target, **patch_opts) as m:
             yield m
+
     return _fixture
+
+
+class _UnitList(list):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.received = self[0].received if self else {}
+        self.received_raw = self[0].received_raw if self else {}
+
+
+class MockEndpoint(MagicMock):
+    def __init__(self, endpoint_name, relation_ids=None):
+        super().__init__()
+        self.is_joined = False
+        self._endpoint_name = endpoint_name
+        self.relations = []
+        if relation_ids:
+            self.relations = [
+                MagicMock(
+                    relation_id=rel_id,
+                    to_publish={},
+                    to_publish_raw={},
+                    joined_units=_UnitList([MagicMock(received={}, received_raw={})]),
+                )
+                for rel_id in relation_ids
+            ]
+        self.all_joined_units = _UnitList(
+            chain.from_iterable(r.joined_units for r in self.relations)
+        )
+
+    @property
+    def endpoint_name(self):
+        return self._endpoint_name
+
+    def expand_name(self, flag):
+        return flag.replace("{endpoint_name}", self.endpoint_name)
+
+    def _get_child_mock(self, **kwargs):
+        return MagicMock(**kwargs)
 
 
 def patch_reactive():
     """
     Setup the standard patches that any reactive charm will require.
     """
-    patch_module('charms.templating')
+    patch_module("charms.templating")
 
-    charms_layer = AutoImportMockPackage(name='charms.layer')
-    charms_layer.import_layer_libs = MagicMock(name='import_layer_libs')
-    patch_module('charms.layer', charms_layer)
+    charms_layer = AutoImportMockPackage(name="charms.layer")
+    charms_layer.import_layer_libs = MagicMock(name="import_layer_libs")
+    patch_module("charms.layer", charms_layer)
 
-    ch = patch_module('charmhelpers')
+    ch = patch_module("charmhelpers")
     ch.core.hookenv.atexit = identity
-    ch.core.hookenv.charm_dir.return_value = 'charm_dir'
+    ch.core.hookenv.charm_dir.return_value = "charm_dir"
 
-    reactive = patch_module('charms.reactive')
+    reactive = patch_module("charms.reactive")
     reactive.when.return_value = identity
     reactive.when_all.return_value = identity
     reactive.when_any.return_value = identity
@@ -264,17 +309,22 @@ def patch_reactive():
     reactive.clear_flag.side_effect = flags.discard
     reactive.set_state.side_effect = flags.add
     reactive.remove_state.side_effect = flags.discard
-    reactive.toggle_flag.side_effect = lambda f, s: (flags.add(f) if s
-                                                     else flags.discard(f))
+    reactive.toggle_flag.side_effect = lambda f, s: (
+        flags.add(f) if s else flags.discard(f)
+    )
     reactive.is_flag_set.side_effect = lambda f: f in flags
     reactive.is_state.side_effect = lambda f: f in flags
     reactive.get_flags.side_effect = lambda: sorted(flags)
     reactive.get_unset_flags.side_effect = lambda *f: sorted(set(f) - flags)
 
-    os.environ['JUJU_MODEL_UUID'] = 'test-1234'
-    os.environ['JUJU_UNIT_NAME'] = 'test/0'
-    os.environ['JUJU_MACHINE_ID'] = '0'
-    os.environ['JUJU_AVAILABILITY_ZONE'] = ''
+    reactive.Endpoint = MockEndpoint
+
+    os.environ["JUJU_MODEL_UUID"] = "test-1234"
+    os.environ["JUJU_UNIT_NAME"] = "test/0"
+    os.environ["JUJU_MACHINE_ID"] = "0"
+    os.environ["JUJU_AVAILABILITY_ZONE"] = ""
+
+    return reactive
 
 
 sys.meta_path.append(MockFinder())

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 SETUP = {
     'name': "charms.unit_test",
-    'version': '1.0.2',
+    'version': '1.1.0',
     'author': "Cory Johns",
     'author_email': "johnsca@gmail.com",
     'url': "https://github.com/juju-solutions/charms.unit_test",

--- a/tests/lib/patched/module/import_over_patch.py
+++ b/tests/lib/patched/module/import_over_patch.py
@@ -1,1 +1,1 @@
-real_or_fake = 'real'
+real_or_fake = "real"

--- a/tests/test_charms_unit_test.py
+++ b/tests/test_charms_unit_test.py
@@ -152,6 +152,40 @@ def test_mock_endpoint():
     assert endpoint.expand_name("{endpoint_name}.foo") == "test.foo"
 
 
+def test_mock_kv():
+    kv = unit_test.MockKV()
+    assert kv == {}
+    kv.set("foo", "bar")
+    # Adapted from charmhelpers test
+    kv.set("docker.net_mtu", 1)
+    kv.set("docker.net_nack", True)
+    kv.set("docker.net_type", "vxlan")
+    assert kv.getrange("docker") == {
+        "docker.net_mtu": 1,
+        "docker.net_type": "vxlan",
+        "docker.net_nack": True,
+    }
+    assert kv.getrange("docker.", True) == {
+        "net_mtu": 1,
+        "net_type": "vxlan",
+        "net_nack": True,
+    }
+    kv.unset("foo")
+    assert kv == {
+        "docker.net_mtu": 1,
+        "docker.net_type": "vxlan",
+        "docker.net_nack": True,
+    }
+    kv.unsetrange(["net_mtu"], "docker.")
+    assert kv == {
+        "docker.net_type": "vxlan",
+        "docker.net_nack": True,
+    }
+    kv.set("foo", "bar")
+    kv.unsetrange(prefix="docker.")
+    assert kv == {"foo": "bar"}
+
+
 def test_patch_reactive():
     unit_test.patch_reactive()
     import charms

--- a/tests/test_charms_unit_test.py
+++ b/tests/test_charms_unit_test.py
@@ -16,33 +16,37 @@ def clean_imports():
 
 
 def test_patch():
-    unit_test.patch_module('dummy')
+    unit_test.patch_module("dummy")
     import dummy
+
     assert isinstance(dummy, MagicMock)
     assert isinstance(dummy.foo, MagicMock)
 
 
 def test_patch_cm():
-    with unit_test.patch_module('dummy.test.foo') as _foo:
+    with unit_test.patch_module("dummy.test.foo") as _foo:
         from dummy.test import foo
+
         assert foo is _foo
     with pytest.raises(ImportError):
         from dummy.test import foo
 
 
 def test_patch_with_patched_ancestor():
-    unit_test.patch_module('dummy')
-    unit_test.patch_module('dummy.test')
+    unit_test.patch_module("dummy")
+    unit_test.patch_module("dummy.test")
     import dummy.test as dummy_test
     import dummy
+
     assert isinstance(dummy_test, MagicMock)
     assert dummy.test is dummy_test
 
 
 def test_patch_with_real_ancestor():
-    unit_test.patch_module('charms.dummy')
+    unit_test.patch_module("charms.dummy")
     import charms.dummy as charms_dummy
     import charms
+
     assert isinstance(charms_dummy, MagicMock)
     assert charms.dummy is charms_dummy
 
@@ -58,62 +62,94 @@ def test_unpatched_with_real_ancestor():
 
 
 def test_unpatched_with_patched_ancestor():
-    unit_test.patch_module('dummy')
+    unit_test.patch_module("dummy")
     from dummy import test
     import dummy.test.module as dummy_test_module
+
     assert isinstance(dummy_test_module, MagicMock)
     assert test.module is dummy_test_module
 
 
 def test_unpatched_with_patched_child():
-    unit_test.patch_module('dummy.test.module')
+    unit_test.patch_module("dummy.test.module")
     import dummy.test
     import dummy.test.module as dummy_test_module
+
     assert isinstance(dummy.test, MagicMock)
     assert isinstance(dummy.test.module, MagicMock)
     assert dummy.test.module is dummy_test_module
 
 
 def test_import_real_over_patched_ancestor():
-    sys.path.insert(0, str(Path(__file__).parent / 'lib'))
-    unit_test.patch_module('patched.module')
+    sys.path.insert(0, str(Path(__file__).parent / "lib"))
+    unit_test.patch_module("patched.module")
     import patched.module.import_over_patch as import_over_patch
     import patched.module
+
     assert not isinstance(import_over_patch, MagicMock)
     assert isinstance(patched.module, MagicMock)
-    assert import_over_patch.real_or_fake == 'real'
+    assert import_over_patch.real_or_fake == "real"
     assert patched.module.import_over_patch is import_over_patch
 
 
-@patch('sys.path', [str(Path(__file__).parent / 'lib')] + sys.path)
+@patch("sys.path", [str(Path(__file__).parent / "lib")] + sys.path)
 def test_auto_import_mock_package():
     import patched
-    mock_package = unit_test.AutoImportMockPackage(name='patched.module')
-    unit_test.patch_module('patched.module', mock_package)
+
+    mock_package = unit_test.AutoImportMockPackage(name="patched.module")
+    unit_test.patch_module("patched.module", mock_package)
     assert not isinstance(patched.module.import_over_patch, MagicMock)
     assert isinstance(patched.module, MagicMock)
-    assert patched.module.import_over_patch.real_or_fake == 'real'
+    assert patched.module.import_over_patch.real_or_fake == "real"
 
 
-@patch('sys.path', [str(Path(__file__).parent / 'lib')] + sys.path)
+@patch("sys.path", [str(Path(__file__).parent / "lib")] + sys.path)
 def test_auto_import_mock_package_from_syntax():
     import patched
-    mock_package = unit_test.AutoImportMockPackage(name='patched.module')
-    unit_test.patch_module('patched.module', mock_package)
+
+    mock_package = unit_test.AutoImportMockPackage(name="patched.module")
+    unit_test.patch_module("patched.module", mock_package)
     from patched.module import import_over_patch
+
     assert not isinstance(import_over_patch, MagicMock)
     assert isinstance(patched.module, MagicMock)
-    assert import_over_patch.real_or_fake == 'real'
+    assert import_over_patch.real_or_fake == "real"
 
 
-@patch('sys.path', [str(Path(__file__).parent / 'lib' / 'patched')] + sys.path)
+@patch("sys.path", [str(Path(__file__).parent / "lib" / "patched")] + sys.path)
 def test_auto_import_mock_package_top_level():
-    mock_package = unit_test.AutoImportMockPackage(name='module')
-    unit_test.patch_module('module', mock_package)
+    mock_package = unit_test.AutoImportMockPackage(name="module")
+    unit_test.patch_module("module", mock_package)
     import module
+
     assert not isinstance(module.import_over_patch, MagicMock)
     assert isinstance(module, MagicMock)
-    assert module.import_over_patch.real_or_fake == 'real'
+    assert module.import_over_patch.real_or_fake == "real"
+
+
+def test_mock_endpoint():
+    endpoint = unit_test.MockEndpoint("test")
+    assert not endpoint.is_joined
+    assert len(endpoint.relations) == 0
+    assert len(list(endpoint.all_joined_units)) == 0
+    endpoint = unit_test.MockEndpoint("test", [1, 2])
+    assert len(endpoint.relations) == 2
+    assert endpoint.relations[0].to_publish == {}
+    assert len(list(endpoint.all_joined_units)) == 2
+    assert endpoint.all_joined_units[0].received == {}
+    assert (
+        endpoint.all_joined_units.received
+        is endpoint.all_joined_units[0].received
+        is endpoint.relations[0].joined_units.received
+        is endpoint.relations[0].joined_units[0].received
+    )
+    assert (
+        endpoint.all_joined_units.received_raw
+        is endpoint.all_joined_units[0].received_raw
+        is endpoint.relations[0].joined_units.received_raw
+        is endpoint.relations[0].joined_units[0].received_raw
+    )
+    assert endpoint.expand_name("{endpoint_name}.foo") == "test.foo"
 
 
 def test_patch_reactive():
@@ -131,44 +167,48 @@ def test_patch_reactive():
 
     @charmhelpers.core.hookenv.atexit
     def test_atexit():
-        return 'ok'
-    assert test_atexit() == 'ok'
+        return "ok"
 
-    @when('foo')
+    assert test_atexit() == "ok"
+
+    @when("foo")
     def test_when():
-        return 'ok'
-    assert test_when() == 'ok'
+        return "ok"
 
-    @when_all('foo', 'bar')
+    assert test_when() == "ok"
+
+    @when_all("foo", "bar")
     def test_when_all():
-        return 'all_ok'
-    assert test_when_all() == 'all_ok'
+        return "all_ok"
 
-    @when_not_all('foo', 'bar', 'baz')
+    assert test_when_all() == "all_ok"
+
+    @when_not_all("foo", "bar", "baz")
     def test_when_not_all():
-        return 'not_all_ok'
-    assert test_when_not_all() == 'not_all_ok'
+        return "not_all_ok"
 
-    assert not is_flag_set('foo')
-    assert not is_state('foo')
-    set_flag('foo')
-    assert is_flag_set('foo')
-    assert is_state('foo')
-    clear_flag('foo')
-    assert not is_flag_set('foo')
-    assert not is_state('foo')
-    set_state('foo')
-    assert is_flag_set('foo')
-    assert is_state('foo')
-    remove_state('foo')
-    assert not is_flag_set('foo')
-    assert not is_state('foo')
-    toggle_flag('foo', False)
-    assert not is_flag_set('foo')
-    toggle_flag('foo', True)
-    assert is_flag_set('foo')
+    assert test_when_not_all() == "not_all_ok"
 
-    assert get_flags() == ['foo']
-    assert get_unset_flags('foo', 'bar') == ['bar']
+    assert not is_flag_set("foo")
+    assert not is_state("foo")
+    set_flag("foo")
+    assert is_flag_set("foo")
+    assert is_state("foo")
+    clear_flag("foo")
+    assert not is_flag_set("foo")
+    assert not is_state("foo")
+    set_state("foo")
+    assert is_flag_set("foo")
+    assert is_state("foo")
+    remove_state("foo")
+    assert not is_flag_set("foo")
+    assert not is_state("foo")
+    toggle_flag("foo", False)
+    assert not is_flag_set("foo")
+    toggle_flag("foo", True)
+    assert is_flag_set("foo")
+
+    assert get_flags() == ["foo"]
+    assert get_unset_flags("foo", "bar") == ["bar"]
 
     assert charms.layer.import_layer_libs

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,16 @@ setenv =
 deps =
     pytest
     flake8
+    black
     ipdb
 commands = pytest --tb native -s {posargs}
 
 [testenv:lint]
 envdir = {toxworkdir}/py3
-commands = flake8 --max-line-length=80 {toxinidir}/charms {toxinidir}/tests
+commands =
+    flake8 {toxinidir}/charms {toxinidir}/tests
+    black --check {toxinidir}/charms {toxinidir}/tests
+
+[flake8]
+exclude=.tox
+max-line-length = 88


### PR DESCRIPTION
When testing interfaces, we need an Endpoint base class which is not a Mock instance and fulfills at least some of the properties of the real Endpoint base class.