### PR TITLE
implement mock on charmhelpers.core.host.restart_on_change

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -8,7 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8]
+        python: 
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+          - '3.10'
 
     steps:
       - uses: actions/checkout@v2

--- a/charms/unit_test.py
+++ b/charms/unit_test.py
@@ -320,6 +320,7 @@ def patch_reactive():
     ch = patch_module("charmhelpers")
     ch.core.hookenv.atexit = identity
     ch.core.hookenv.charm_dir.return_value = "charm_dir"
+    ch.core.host.restart_on_change.return_value = identity
     ch.core.unitdata.kv.return_value = MockKV()
 
     reactive = patch_module("charms.reactive")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 SETUP = {
     'name': "charms.unit_test",
-    'version': '1.1.0',
+    'version': '1.1.1',
     'author': "Cory Johns",
     'author_email': "johnsca@gmail.com",
     'url': "https://github.com/juju-solutions/charms.unit_test",


### PR DESCRIPTION
methods like these that are decorated with with `charmhelpers.core.host.restart_on_change` need the following mock defined so the decorated method is actually called

example from [charmed-kubernetes/control-plane](https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/blob/c71fd1a1bd41ea5d8640c4814d22e31231dd6f3c/reactive/kubernetes_control_plane.py#L1126-L1136)

```python
@when("etcd.available", "tls_client.certs.saved")
@restart_on_change(
    {
        auth_webhook_conf: [auth_webhook_svc_name],
        auth_webhook_exe: [auth_webhook_svc_name],
        auth_webhook_svc: [auth_webhook_svc_name],
    }
)
def register_auth_webhook():
    """Render auth webhook templates and start the related service."""
    Path(auth_webhook_root).mkdir(exist_ok=True)
```