### PR TITLE
Appropriately mock a mock module's `__spec__` attribute with a ModuleSpec

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -19,9 +19,9 @@ jobs:
             python: '3.6'
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox and any other packages

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -4,17 +4,20 @@ on: [push]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: 
-          - '3.6'
+        os: 
+          - ubuntu-22.04
+        python:
           - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
-
+          - '3.11'
+        include:
+          - os: ubuntu-20.04
+            python: '3.6'
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/charms/unit_test.py
+++ b/charms/unit_test.py
@@ -198,6 +198,8 @@ class MockLoader:
         if not hasattr(replacement, "__path__"):
             replacement.__name__ = fullname
             replacement.__path__ = []
+        if not hasattr(replacement, "__spec__"):
+            replacement.__spec__ = ModuleSpec(fullname, cls)
         sys.modules[fullname] = replacement
         _debug("Patched {}", fullname, color="green")
         return replacement


### PR DESCRIPTION
mocks for imported modules require a `__spec__` attribute in python 3.11
https://docs.python.org/3/reference/import.html#module-spec